### PR TITLE
feat: Add spec sync system for tracking acceptance criteria implementation

### DIFF
--- a/.github/workflows/spec-sync-validate.yml
+++ b/.github/workflows/spec-sync-validate.yml
@@ -1,0 +1,44 @@
+name: Validate Spec Sync
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  validate:
+    name: Validate Spec Sync Configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.3
+          bundler-cache: true
+
+      - name: Validate spec sync
+        run: bundle exec rake spec_sync:validate
+
+      - name: Report status
+        if: success()
+        run: echo "✓ Spec sync configuration is valid"
+
+      - name: Explain error
+        if: failure()
+        run: |
+          echo "✗ Spec sync validation failed"
+          echo ""
+          echo "This usually means one of:"
+          echo "  1. A criterion reference in specs/implementation_status.yml doesn't exist in the specs"
+          echo "  2. An invalid manual status (use: todo, in_progress, or blocked)"
+          echo ""
+          echo "To debug locally:"
+          echo "  bundle exec rake spec_sync:validate"
+          exit 1

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,0 +1,154 @@
+# Copilot Agent Instructions for simple-nimble
+
+## Overview
+
+This project uses a **spec sync system** to track which acceptance criteria from product specifications have been implemented. As you work, help developers connect their code to the specifications it implements.
+
+## Key Concepts
+
+### Specification and Acceptance Criteria
+
+- **Specs:** Product specifications in `specs/app/[0-9][0-9]-*.md`
+- **Acceptance Criteria:** Requirements within each spec that define completion
+- **Reference format:** `S-NN:AC-N` (e.g., `S-05:AC-1`)
+  - `S-05` = Specification 05 (Character Creation)
+  - `AC-1` = First Acceptance Criterion in that spec
+
+### How Spec Sync Tracks Implementation
+
+The system uses two signals:
+
+1. **Git history:** Commits that mention `S-NN:AC-N` are auto-detected as implementing that criterion
+2. **Manual marks:** Developers can explicitly mark criteria as `in_progress` or `blocked`
+
+## When Writing Code
+
+### 1. Understand the Spec
+
+When working on a feature, check what specs it relates to:
+
+```bash
+bundle exec rake spec_sync:status[S-05]
+```
+
+This shows all acceptance criteria for that spec and their implementation status.
+
+### 2. Write Spec-Aware Commits
+
+When your code implements an acceptance criterion, mention it in the commit message:
+
+```bash
+git commit -m "feat: Add character creation form
+
+- Build form component per S-05:AC-1
+- Implement validation logic per S-05:AC-2
+- Calculate derived attributes per S-05:AC-3
+
+Closes #42"
+```
+
+Format: Include `S-NN:AC-N` anywhere in the commit subject or body.
+
+**Why this matters:**
+- Traces code back to product requirements
+- Auto-marks criteria as done in spec sync
+- Makes review and debugging easier
+- Maintains spec-to-code alignment
+
+### 3. Mark Work in Progress
+
+Before starting work, mark criteria as `in_progress`:
+
+```bash
+bundle exec rake "spec_sync:mark[S-05:AC-1,in_progress,Building form component]"
+```
+
+This tells other developers you're working on it.
+
+### 4. Handle Blockers
+
+If you're blocked waiting on something, mark it:
+
+```bash
+bundle exec rake "spec_sync:mark[S-06:AC-2,blocked,Waiting for character lifecycle model (S-04)]"
+```
+
+## Helpful Commands
+
+```bash
+# View all criteria for a spec
+bundle exec rake spec_sync:status[S-05]
+
+# View one criterion
+bundle exec rake "spec_sync:status[S-05:AC-1]"
+
+# View all criteria across all specs
+bundle exec rake spec_sync:status
+
+# Mark a criterion
+bundle exec rake "spec_sync:mark[S-05:AC-1,in_progress,Building form]"
+
+# Clear a manual mark
+bundle exec rake "spec_sync:mark[S-05:AC-1,todo]"
+
+# Validate spec sync config
+bundle exec rake spec_sync:validate
+```
+
+## When Helping with Code
+
+### Before Writing Code
+- Ask: "Which acceptance criteria does this implement?"
+- Suggest: Run `rake spec_sync:status[S-XX]` to see requirements
+- Encourage: Reading the relevant spec document first
+
+### While Writing Code
+- Suggest: Breaking work into acceptance-criteria-sized chunks
+- Encourage: Writing code that satisfies one criterion at a time
+- Remind: Mention criteria in commit messages
+
+### In Code Review
+- Check: Do commits mention the specs they implement?
+- Suggest: Adding missing `S-NN:AC-N` references
+- Validate: Does the code actually satisfy the mentioned criteria?
+
+### Example Guidance
+
+When a developer asks to implement "character validation":
+
+```
+Good approach:
+1. Read spec 05-character-creation.md section 8 (Acceptance Criteria)
+2. Identify relevant criteria (e.g., S-05:AC-1, S-05:AC-2, S-05:AC-4)
+3. Mark them as in_progress
+4. Build form validation
+5. Commit with: "feat: Add character form validation per S-05:AC-1 and S-05:AC-2"
+6. Run rake spec_sync:status[S-05] to verify they're linked
+```
+
+## Spec Sync System Files
+
+- `lib/spec_sync/` - System code (parsers, trackers, indexers)
+- `lib/tasks/spec_sync.rake` - Rake task definitions
+- `specs/app/[0-9][0-9]-*.md` - Product specifications
+- `specs/implementation_status.yml` - Manual status overrides
+- `.github/workflows/spec-sync-validate.yml` - CI validation
+
+## Key Design Principles
+
+1. **Git is the source of truth** — Mention criteria in commits
+2. **Specs drive implementation** — Code should satisfy acceptance criteria
+3. **Manual marks track active work** — Use `in_progress`/`blocked` for WIP
+4. **No "done" manual status** — Done comes only from git commits
+5. **Always fresh data** — Status computed on-demand from current state
+
+## References
+
+- Spec template: `specs/app/SPEC_TEMPLATE.md`
+- Spec index: `specs/app/SPEC_INDEX.md`
+- Implementation tracking: `specs/README.md` (Spec Sync section)
+- Full documentation: See session workspace documents (architecture, bugs, quick reference)
+
+---
+
+**TL;DR:** When implementing a feature, check the relevant spec, mark criteria as you work, mention them in commits, and the system automatically tracks progress. Done!

--- a/lib/spec_sync.rb
+++ b/lib/spec_sync.rb
@@ -1,0 +1,2 @@
+module SpecSync
+end

--- a/lib/spec_sync/acceptance_criterion.rb
+++ b/lib/spec_sync/acceptance_criterion.rb
@@ -1,0 +1,3 @@
+module SpecSync
+  AcceptanceCriterion = Data.define(:reference, :type, :criterion, :spec_confidence)
+end

--- a/lib/spec_sync/catalog.rb
+++ b/lib/spec_sync/catalog.rb
@@ -1,0 +1,95 @@
+require "pathname"
+
+module SpecSync
+  class Catalog
+    SPEC_GLOB = "specs/app/[0-9][0-9]-*.md"
+    ACCEPTANCE_CRITERIA_HEADING = "## 8. Acceptance criteria"
+
+    def initialize(root: Rails.root)
+      @root = Pathname(root)
+    end
+
+    def specs
+      spec_paths.map { |path| parse_spec(path) }
+    end
+
+    def references
+      specs.flat_map(&:acceptance_criteria).map(&:reference)
+    end
+
+    private
+
+    attr_reader :root
+
+    def spec_paths
+      Dir[root.join(SPEC_GLOB)].sort.map { |path| Pathname(path) }
+    end
+
+    def parse_spec(path)
+      content = path.read
+      spec_id = extract_spec_id(path)
+      title = content[/^# Specification:\s+(.+)$/, 1]
+      status = content[/^> \*\*Status:\*\*\s+(.+)$/, 1]
+
+      raise "Missing specification title in #{path}" if title.nil?
+      raise "Missing specification status in #{path}" if status.nil?
+
+      acceptance_criteria = parse_acceptance_criteria(content, spec_id)
+
+      SpecDocument.new(
+        id: spec_id,
+        title: title.strip,
+        status: status.strip,
+        path: path.relative_path_from(root).to_s,
+        acceptance_criteria:
+      )
+    end
+
+    def extract_spec_id(path)
+      basename = path.basename.to_s
+      prefix = basename[/\A(\d{2})-/, 1]
+      raise "Cannot derive spec ID from #{basename}" if prefix.nil?
+
+      "S-#{prefix}"
+    end
+
+    def parse_acceptance_criteria(content, spec_id)
+      section = content.split(/^#{Regexp.escape(ACCEPTANCE_CRITERIA_HEADING)}$/).last
+      raise "Missing acceptance criteria section for #{spec_id}" if section.nil?
+
+      table_lines = section.lines.drop_while { |line| !line.start_with?("|") }
+      table_lines = table_lines.take_while { |line| line.start_with?("|") }
+      headers, rows = parse_markdown_table(table_lines)
+
+      rows.map do |row|
+        criterion_id = row.fetch("ID").strip
+        AcceptanceCriterion.new(
+          reference: Reference.new(spec_id:, criterion_id:),
+          type: row.fetch("Type").strip,
+          criterion: row.fetch("Criterion").strip,
+          spec_confidence: normalize_status(row.fetch("Status"))
+        )
+      end
+    end
+
+    def parse_markdown_table(lines)
+      raise "Expected markdown table lines" if lines.length < 2
+
+      headers = split_markdown_row(lines.first)
+      rows = lines.drop(2).reject { |line| line.strip.empty? }.map do |line|
+        values = split_markdown_row(line)
+        headers.zip(values).to_h
+      end
+
+      [headers, rows]
+    end
+
+    def split_markdown_row(line)
+      line.split("|").drop(1).map(&:strip).tap(&:pop)
+    end
+
+    def normalize_status(value)
+      value.strip.delete_prefix("`").delete_suffix("`")
+    end
+  end
+end

--- a/lib/spec_sync/catalog.rb
+++ b/lib/spec_sync/catalog.rb
@@ -81,7 +81,7 @@ module SpecSync
         headers.zip(values).to_h
       end
 
-      [headers, rows]
+      [ headers, rows ]
     end
 
     def split_markdown_row(line)

--- a/lib/spec_sync/commit_link.rb
+++ b/lib/spec_sync/commit_link.rb
@@ -1,0 +1,3 @@
+module SpecSync
+  CommitLink = Data.define(:sha, :summary)
+end

--- a/lib/spec_sync/git_commit_index.rb
+++ b/lib/spec_sync/git_commit_index.rb
@@ -38,7 +38,7 @@ module SpecSync
         next unless record.include?("\x00")
 
         sha, message = record.sub(/\A\n+/, "").split("\x00", 2)
-        [sha, message.to_s]
+        [ sha, message.to_s ]
       end
     end
   end

--- a/lib/spec_sync/git_commit_index.rb
+++ b/lib/spec_sync/git_commit_index.rb
@@ -1,0 +1,45 @@
+require "open3"
+
+module SpecSync
+  class GitCommitIndex
+    REFERENCE_PATTERN = /\bS-\d{2}:AC-\d+\b/
+
+    def initialize(root: Rails.root)
+      @root = root
+    end
+
+    def links_by_reference
+      @links_by_reference ||= begin
+        links = Hash.new { |hash, key| hash[key] = [] }
+
+        commit_pairs.each do |sha, message|
+          summary = message.lines.first.to_s.strip
+          message.scan(REFERENCE_PATTERN).uniq.each do |reference|
+            links[reference] << CommitLink.new(sha:, summary:)
+          end
+        end
+
+        links.transform_values(&:freeze)
+      end
+    end
+
+    private
+
+    attr_reader :root
+
+    def commit_pairs
+      stdout, stderr, status = Open3.capture3(
+        "git", "--no-pager", "log", "--format=%H%x00%B%x1e",
+        chdir: root.to_s
+      )
+      raise "Unable to read git history: #{stderr}" unless status.success?
+
+      stdout.split("\x1e").filter_map do |record|
+        next unless record.include?("\x00")
+
+        sha, message = record.sub(/\A\n+/, "").split("\x00", 2)
+        [sha, message.to_s]
+      end
+    end
+  end
+end

--- a/lib/spec_sync/reference.rb
+++ b/lib/spec_sync/reference.rb
@@ -1,0 +1,32 @@
+module SpecSync
+  class Reference
+    PATTERN = /\A(S-\d{2}):(AC-\d+)\z/
+
+    attr_reader :spec_id, :criterion_id
+
+    def self.parse(value)
+      match = PATTERN.match(value.to_s.strip)
+      raise ArgumentError, "Invalid criterion reference: #{value.inspect}" unless match
+
+      new(spec_id: match[1], criterion_id: match[2])
+    end
+
+    def initialize(spec_id:, criterion_id:)
+      @spec_id = spec_id
+      @criterion_id = criterion_id
+    end
+
+    def to_s
+      "#{spec_id}:#{criterion_id}"
+    end
+
+    def ==(other)
+      other.is_a?(Reference) && other.to_s == to_s
+    end
+    alias eql? ==
+
+    def hash
+      to_s.hash
+    end
+  end
+end

--- a/lib/spec_sync/spec_document.rb
+++ b/lib/spec_sync/spec_document.rb
@@ -1,0 +1,3 @@
+module SpecSync
+  SpecDocument = Data.define(:id, :title, :status, :path, :acceptance_criteria)
+end

--- a/lib/spec_sync/status_store.rb
+++ b/lib/spec_sync/status_store.rb
@@ -1,0 +1,78 @@
+require "yaml"
+
+module SpecSync
+  class StatusStore
+    ALLOWED_STATUSES = %w[todo in_progress blocked].freeze
+
+    attr_reader :path
+
+    def initialize(path: Rails.root.join("specs/implementation_status.yml"))
+      @path = Pathname(path)
+    end
+
+    def manual_status(reference)
+      normalized_state = states.fetch("criteria", {}).fetch(reference.to_s, nil)
+      return nil if normalized_state.nil?
+
+      normalized_state.fetch("status")
+    end
+
+    def note(reference)
+      normalized_state = states.fetch("criteria", {}).fetch(reference.to_s, nil)
+      normalized_state&.fetch("notes", nil)
+    end
+
+    def update(reference:, status:, notes: nil, timestamp: Time.current.iso8601)
+      normalized_status = status.to_s.strip
+      unless ALLOWED_STATUSES.include?(normalized_status)
+        raise ArgumentError, "Status must be one of: #{ALLOWED_STATUSES.join(', ')}"
+      end
+
+      payload = states
+      payload["criteria"] ||= {}
+
+      if normalized_status == "todo"
+        payload["criteria"].delete(reference.to_s)
+      else
+        payload["criteria"][reference.to_s] = {
+          "status" => normalized_status,
+          "updated_at" => timestamp
+        }
+        payload["criteria"][reference.to_s]["notes"] = notes.to_s.strip unless notes.to_s.strip.empty?
+      end
+
+      write(payload)
+    end
+
+    def validate!(valid_references:)
+      invalid_states = states.fetch("criteria", {}).each_with_object([]) do |(key, value), errors|
+        errors << "Unknown criterion reference in status store: #{key}" unless valid_references.include?(key)
+
+        status = value.fetch("status", nil)
+        next if ALLOWED_STATUSES.include?(status)
+
+        errors << "Unsupported manual status for #{key}: #{status.inspect}"
+      end
+
+      raise invalid_states.join("\n") if invalid_states.any?
+    end
+
+    private
+
+    def states
+      @states ||= begin
+        if path.exist?
+          YAML.safe_load(path.read, permitted_classes: [], aliases: false) || {}
+        else
+          {}
+        end
+      end
+    end
+
+    def write(payload)
+      @states = payload
+      path.dirname.mkpath
+      path.write(payload.to_yaml)
+    end
+  end
+end

--- a/lib/spec_sync/tracker.rb
+++ b/lib/spec_sync/tracker.rb
@@ -1,0 +1,74 @@
+module SpecSync
+  CriterionStatus = Data.define(
+    :reference,
+    :spec_title,
+    :spec_status,
+    :spec_path,
+    :type,
+    :criterion,
+    :spec_confidence,
+    :implementation_status,
+    :manual_status,
+    :commit_links
+  )
+
+  class Tracker
+    def initialize(catalog: Catalog.new, status_store: StatusStore.new, git_commit_index: GitCommitIndex.new)
+      @catalog = catalog
+      @status_store = status_store
+      @git_commit_index = git_commit_index
+    end
+
+    def criterion_statuses(filter: nil)
+      normalized_filter = filter.to_s.strip
+      catalog.specs.flat_map do |spec|
+        spec.acceptance_criteria.filter_map do |criterion|
+          status_row_for(spec:, criterion:, filter: normalized_filter)
+        end
+      end
+    end
+
+    def validate!
+      status_store.validate!(valid_references: catalog.references.map(&:to_s).to_set)
+      true
+    end
+
+    private
+
+    attr_reader :catalog, :status_store, :git_commit_index
+
+    def status_row_for(spec:, criterion:, filter:)
+      return nil unless matches_filter?(spec:, criterion:, filter:)
+
+      manual_status = status_store.manual_status(criterion.reference)
+      commit_links = git_commit_index.links_by_reference.fetch(criterion.reference.to_s, [])
+      implementation_status = resolve_implementation_status(manual_status:, commit_links:)
+
+      CriterionStatus.new(
+        reference: criterion.reference,
+        spec_title: spec.title,
+        spec_status: spec.status,
+        spec_path: spec.path,
+        type: criterion.type,
+        criterion: criterion.criterion,
+        spec_confidence: criterion.spec_confidence,
+        implementation_status:,
+        manual_status:,
+        commit_links:
+      )
+    end
+
+    def matches_filter?(spec:, criterion:, filter:)
+      return true if filter.empty?
+
+      filter == spec.id || filter == criterion.reference.to_s
+    end
+
+    def resolve_implementation_status(manual_status:, commit_links:)
+      return manual_status if %w[in_progress blocked].include?(manual_status)
+      return "done" if commit_links.any?
+
+      "todo"
+    end
+  end
+end

--- a/lib/tasks/spec_sync.rake
+++ b/lib/tasks/spec_sync.rake
@@ -1,0 +1,62 @@
+namespace :spec_sync do
+  desc "Show spec acceptance-criteria implementation status"
+  task :status, [:filter] => :environment do |_task, args|
+    tracker = SpecSync::Tracker.new
+    tracker.validate!
+
+    statuses = tracker.criterion_statuses(filter: args[:filter])
+    grouped = statuses.group_by(&:spec_title)
+
+    puts "Spec sync status"
+    puts "================"
+    puts
+
+    if grouped.empty?
+      puts "No matching specs found."
+      next
+    end
+
+    grouped.each_value do |criteria|
+      first = criteria.first
+      puts "#{first.reference.spec_id} - #{first.spec_title} (spec status: #{first.spec_status})"
+      puts "  Source: #{first.spec_path}"
+
+      criteria.each do |criterion|
+        puts "  - #{criterion.reference} [#{criterion.implementation_status}] #{criterion.type}"
+        puts "    #{criterion.criterion}"
+        puts "    Spec confidence: #{criterion.spec_confidence}"
+        puts "    Manual state: #{criterion.manual_status}" if criterion.manual_status
+
+        if criterion.commit_links.any?
+          criterion.commit_links.first(3).each do |link|
+            puts "    Commit: #{link.sha[0, 7]} #{link.summary}"
+          end
+          remaining = criterion.commit_links.length - 3
+          puts "    ... #{remaining} more commit(s)" if remaining.positive?
+        end
+      end
+
+      puts
+    end
+  end
+
+  desc "Set a manual implementation status for an acceptance criterion"
+  task :mark, [:reference, :status, :notes] => :environment do |_task, args|
+    reference = SpecSync::Reference.parse(args[:reference])
+    tracker = SpecSync::Tracker.new
+    tracker.validate!
+
+    unless tracker.criterion_statuses(filter: reference.to_s).any?
+      abort "Unknown criterion reference: #{reference}"
+    end
+
+    SpecSync::StatusStore.new.update(reference:, status: args[:status], notes: args[:notes])
+    puts "Updated #{reference} to #{args[:status]}"
+  end
+
+  desc "Validate the spec sync catalog, status store, and references"
+  task validate: :environment do
+    SpecSync::Tracker.new.validate!
+    puts "Spec sync configuration is valid."
+  end
+end

--- a/lib/tasks/spec_sync.rake
+++ b/lib/tasks/spec_sync.rake
@@ -1,6 +1,6 @@
 namespace :spec_sync do
   desc "Show spec acceptance-criteria implementation status"
-  task :status, [:filter] => :environment do |_task, args|
+  task :status, [ :filter ] => :environment do |_task, args|
     tracker = SpecSync::Tracker.new
     tracker.validate!
 
@@ -41,7 +41,7 @@ namespace :spec_sync do
   end
 
   desc "Set a manual implementation status for an acceptance criterion"
-  task :mark, [:reference, :status, :notes] => :environment do |_task, args|
+  task :mark, [ :reference, :status, :notes ] => :environment do |_task, args|
     reference = SpecSync::Reference.parse(args[:reference])
     tracker = SpecSync::Tracker.new
     tracker.validate!

--- a/specs/README.md
+++ b/specs/README.md
@@ -34,3 +34,150 @@ Start with these files in `application/`:
 - The documents above are draftable now with a mix of known decisions and explicit TBDs.
 - Any unresolved decision that blocks implementation is marked as `[Unknown: TBD]`.
 - These specs should be updated as decisions are validated, not treated as frozen prose.
+
+## Spec Sync: Tracking Acceptance Criteria Implementation
+
+Each specification document (01 through 09) contains **acceptance criteria** in section 8. These criteria define what must be true for the feature to be considered complete.
+
+The `spec sync` system automatically tracks which acceptance criteria have been implemented, are in-progress, blocked, or still todo.
+
+### How It Works
+
+1. **System reads specs** from `app/[0-9][0-9]-*.md`
+2. **Extracts acceptance criteria** (marked as AC-1, AC-2, etc.)
+3. **Tracks implementation status** via:
+   - **Manual marks** (stored in `implementation_status.yml`)
+   - **Git history** (scans commit messages for criterion references)
+4. **Shows unified status** via rake tasks
+
+### Reference Format
+
+Acceptance criteria use the format **`S-NN:AC-N`** where:
+- `S-NN` = Spec number (e.g., S-05 for character creation)
+- `AC-N` = Acceptance criterion number (e.g., AC-1, AC-2)
+
+Example: `S-05:AC-1` refers to the first acceptance criterion in spec 05-character-creation.md
+
+### Usage
+
+#### View Implementation Status
+
+```bash
+# See all criteria across all specs
+bundle exec rake spec_sync:status
+
+# Filter to one spec
+bundle exec rake "spec_sync:status[S-05]"
+
+# Filter to one criterion
+bundle exec rake "spec_sync:status[S-05:AC-1]"
+```
+
+Output shows each criterion with:
+- Reference (e.g., S-05:AC-1)
+- Implementation status: `todo`, `in_progress`, `blocked`, or `done`
+- Criterion text
+- Spec confidence level from the spec document
+- Manual status (if set)
+- Linked commits (if found in git history)
+
+#### Mark a Criterion
+
+```bash
+# Mark as in-progress with notes
+bundle exec rake "spec_sync:mark[S-05:AC-1,in_progress,Building form validation]"
+
+# Mark as blocked with reason
+bundle exec rake "spec_sync:mark[S-06:AC-2,blocked,Waiting for character lifecycle model]"
+
+# Clear manual mark (reverts to based on git history)
+bundle exec rake "spec_sync:mark[S-05:AC-1,todo]"
+```
+
+#### Validate Configuration
+
+```bash
+bundle exec rake spec_sync:validate
+```
+
+### Implementation Status
+
+Each criterion has a status computed from:
+
+1. **Manual override** (if you explicitly marked it)
+   - `in_progress` — work is actively happening
+   - `blocked` — cannot proceed without something else
+
+2. **Git history** (if any commit mentions the criterion)
+   - Commit message: `"feat: Add validation for S-05:AC-1"`
+   - System finds the reference → marks criterion as `done`
+
+3. **Default** (if neither above apply)
+   - `todo` — not yet started
+
+Priority: Manual overrides take precedence over git history, which takes precedence over the default.
+
+### Workflow Example
+
+```bash
+# Day 1: Start working on character creation acceptance criteria
+$ bundle exec rake "spec_sync:mark[S-05:AC-1,in_progress,Designing form]"
+$ bundle exec rake "spec_sync:mark[S-05:AC-2,in_progress,Implementing validation]"
+
+# View progress
+$ bundle exec rake spec_sync:status[S-05]
+
+# Day 2: Hit a blocker
+$ bundle exec rake "spec_sync:mark[S-05:AC-1,blocked,Waiting for schema design]"
+
+# Day 3: Complete and commit work
+$ git commit -m "feat: Add character creation form
+
+- Implement form layout per S-05:AC-1
+- Add field validation per S-05:AC-2
+- Calculate derived attributes per S-05:AC-3"
+
+# System now shows criteria as [done] automatically
+$ bundle exec rake spec_sync:status[S-05]
+S-05:AC-1 [done] ... (auto-detected from commit)
+S-05:AC-2 [done] ... (auto-detected from commit)
+S-05:AC-3 [done] ... (auto-detected from commit)
+```
+
+### Files
+
+- `implementation_status.yml` — Manual status overrides (sparse YAML)
+- `app/[0-9][0-9]-*.md` — Product specifications with acceptance criteria
+- `lib/spec_sync/` — System code (parsers, trackers, indexers)
+- `lib/tasks/spec_sync.rake` — Rake task definitions
+
+### Key Design Principles
+
+- **Git is the source of truth** — Mention criteria in commits; no separate "done" marking needed
+- **Manual marks are for work-in-progress** — Use `in_progress` and `blocked` to track active work
+- **No "done" manual status** — Done comes only from git history
+- **Sparse storage** — YAML only stores exceptions (not-todo statuses)
+- **Always fresh** — Status is computed on-demand, never stale
+
+### For Developers
+
+When you complete work on a criterion, mention it in your commit message:
+
+```bash
+git commit -m "feat: Implement character creation validation
+
+- Add form validations per S-05:AC-1
+- Prevent invalid combinations per S-05:AC-2
+- Handle edge cases per S-05:AC-5
+
+Closes #42"
+```
+
+The system will automatically scan the commit message, find `S-05:AC-1`, `S-05:AC-2`, and `S-05:AC-5`, and link them to that commit. When you run `rake spec_sync:status`, those criteria will show as `[done]` with the commit linked.
+
+### Documentation
+
+For detailed information, see the session workspace documents:
+- **Quick Reference** — How to use the system with practical examples
+- **Architecture** — Deep dive into how the system works
+- **Bug Fixes** — What was fixed and why (includes before/after code)

--- a/specs/README.md
+++ b/specs/README.md
@@ -181,3 +181,31 @@ For detailed information, see the session workspace documents:
 - **Quick Reference** — How to use the system with practical examples
 - **Architecture** — Deep dive into how the system works
 - **Bug Fixes** — What was fixed and why (includes before/after code)
+
+### Commit Message Tips
+
+When your changes implement one or more acceptance criteria, mention them in the commit message. The system will automatically link those commits to the criteria.
+
+**Example commit:**
+
+```bash
+git commit -m "feat: Add character creation form and validation
+
+- Build character creation wizard per S-05:AC-1
+- Implement field validation rules per S-05:AC-2
+- Calculate derived attributes per S-05:AC-3
+- Add test coverage for all scenarios
+
+Closes #42"
+```
+
+The system will find `S-05:AC-1`, `S-05:AC-2`, and `S-05:AC-3`, and automatically mark them as `[done]` when you run `rake spec_sync:status`.
+
+**Format:** Mention criteria as `S-NN:AC-N` anywhere in the commit message (subject or body).
+
+**View progress:** After pushing, run:
+```bash
+bundle exec rake spec_sync:status[S-05]
+```
+
+You should see your commits linked to the criteria they implement.

--- a/specs/implementation_status.yml
+++ b/specs/implementation_status.yml
@@ -1,0 +1,3 @@
+---
+version: 1
+criteria: {}

--- a/test/lib/spec_sync/catalog_test.rb
+++ b/test/lib/spec_sync/catalog_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class SpecSyncCatalogTest < ActiveSupport::TestCase
+  test "parses numbered specs and acceptance criteria" do
+    catalog = SpecSync::Catalog.new
+
+    spec = catalog.specs.find { |entry| entry.id == "S-05" }
+
+    assert_not_nil spec
+    assert_equal "Character Creation", spec.title
+    assert_equal "specs/app/05-character-creation.md", spec.path
+
+    criterion = spec.acceptance_criteria.find { |entry| entry.reference.to_s == "S-05:AC-1" }
+
+    assert_not_nil criterion
+    assert_equal "Behavioral", criterion.type
+    assert_match(/prevents finalization until they are valid/i, criterion.criterion)
+    assert_equal "[Assumed: verify]", criterion.spec_confidence
+  end
+end

--- a/test/lib/spec_sync/status_store_test.rb
+++ b/test/lib/spec_sync/status_store_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "tmpdir"
+
+class SpecSyncStatusStoreTest < ActiveSupport::TestCase
+  test "writes sparse manual states and removes todo entries" do
+    Dir.mktmpdir do |dir|
+      store = SpecSync::StatusStore.new(path: File.join(dir, "implementation_status.yml"))
+      reference = SpecSync::Reference.parse("S-05:AC-1")
+
+      store.update(reference:, status: "in_progress", notes: "Building the wizard")
+
+      assert_equal "in_progress", store.manual_status(reference)
+      assert_equal "Building the wizard", store.note(reference)
+
+      store.update(reference:, status: "todo")
+
+      assert_nil store.manual_status(reference)
+    end
+  end
+
+  test "rejects unsupported manual statuses" do
+    Dir.mktmpdir do |dir|
+      store = SpecSync::StatusStore.new(path: File.join(dir, "implementation_status.yml"))
+
+      error = assert_raises(ArgumentError) do
+        store.update(reference: SpecSync::Reference.parse("S-05:AC-1"), status: "done")
+      end
+
+      assert_match(/Status must be one of/, error.message)
+    end
+  end
+end

--- a/test/lib/spec_sync/tracker_test.rb
+++ b/test/lib/spec_sync/tracker_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class SpecSyncTrackerTest < ActiveSupport::TestCase
+  FakeCatalog = Struct.new(:specs, :references)
+  FakeStore = Struct.new(:manual_statuses) do
+    def manual_status(reference)
+      manual_statuses[reference.to_s]
+    end
+
+    def validate!(valid_references:)
+      invalid = manual_statuses.keys - valid_references.to_a
+      raise "Invalid references: #{invalid.join(', ')}" if invalid.any?
+    end
+  end
+
+  FakeGitCommitIndex = Struct.new(:links_by_reference)
+
+  test "resolves done from git links and active work from manual status" do
+    reference = SpecSync::Reference.parse("S-06:AC-2")
+    criterion = SpecSync::AcceptanceCriterion.new(
+      reference:,
+      type: "Behavioral",
+      criterion: "Allows only legal choices",
+      spec_confidence: "[Validated]"
+    )
+    spec = SpecSync::SpecDocument.new(
+      id: "S-06",
+      title: "Level-Up",
+      status: "Draft",
+      path: "specs/app/06-level-up.md",
+      acceptance_criteria: [criterion]
+    )
+
+    tracker = SpecSync::Tracker.new(
+      catalog: FakeCatalog.new([spec], [reference]),
+      status_store: FakeStore.new({ "S-06:AC-2" => "blocked" }),
+      git_commit_index: FakeGitCommitIndex.new({
+        "S-06:AC-2" => [SpecSync::CommitLink.new(sha: "abcdef1", summary: "feat: cover S-06:AC-2")]
+      })
+    )
+
+    status = tracker.criterion_statuses.first
+
+    assert_equal "blocked", status.implementation_status
+    assert_equal "blocked", status.manual_status
+    assert_equal 1, status.commit_links.length
+  end
+
+  test "filters by spec id or exact criterion reference" do
+    first_reference = SpecSync::Reference.parse("S-05:AC-1")
+    second_reference = SpecSync::Reference.parse("S-06:AC-1")
+    specs = [
+      SpecSync::SpecDocument.new(
+        id: "S-05",
+        title: "Character Creation",
+        status: "Draft",
+        path: "specs/app/05-character-creation.md",
+        acceptance_criteria: [
+          SpecSync::AcceptanceCriterion.new(
+            reference: first_reference,
+            type: "Behavioral",
+            criterion: "Criterion one",
+            spec_confidence: "[Validated]"
+          )
+        ]
+      ),
+      SpecSync::SpecDocument.new(
+        id: "S-06",
+        title: "Level-Up",
+        status: "Draft",
+        path: "specs/app/06-level-up.md",
+        acceptance_criteria: [
+          SpecSync::AcceptanceCriterion.new(
+            reference: second_reference,
+            type: "Behavioral",
+            criterion: "Criterion two",
+            spec_confidence: "[Validated]"
+          )
+        ]
+      )
+    ]
+
+    tracker = SpecSync::Tracker.new(
+      catalog: FakeCatalog.new(specs, [first_reference, second_reference]),
+      status_store: FakeStore.new({}),
+      git_commit_index: FakeGitCommitIndex.new({})
+    )
+
+    assert_equal ["S-05:AC-1"], tracker.criterion_statuses(filter: "S-05").map { |row| row.reference.to_s }
+    assert_equal ["S-06:AC-1"], tracker.criterion_statuses(filter: "S-06:AC-1").map { |row| row.reference.to_s }
+  end
+end

--- a/test/lib/spec_sync/tracker_test.rb
+++ b/test/lib/spec_sync/tracker_test.rb
@@ -28,14 +28,14 @@ class SpecSyncTrackerTest < ActiveSupport::TestCase
       title: "Level-Up",
       status: "Draft",
       path: "specs/app/06-level-up.md",
-      acceptance_criteria: [criterion]
+      acceptance_criteria: [ criterion ]
     )
 
     tracker = SpecSync::Tracker.new(
-      catalog: FakeCatalog.new([spec], [reference]),
+      catalog: FakeCatalog.new([ spec ], [ reference ]),
       status_store: FakeStore.new({ "S-06:AC-2" => "blocked" }),
       git_commit_index: FakeGitCommitIndex.new({
-        "S-06:AC-2" => [SpecSync::CommitLink.new(sha: "abcdef1", summary: "feat: cover S-06:AC-2")]
+        "S-06:AC-2" => [ SpecSync::CommitLink.new(sha: "abcdef1", summary: "feat: cover S-06:AC-2") ]
       })
     )
 
@@ -81,12 +81,12 @@ class SpecSyncTrackerTest < ActiveSupport::TestCase
     ]
 
     tracker = SpecSync::Tracker.new(
-      catalog: FakeCatalog.new(specs, [first_reference, second_reference]),
+      catalog: FakeCatalog.new(specs, [ first_reference, second_reference ]),
       status_store: FakeStore.new({}),
       git_commit_index: FakeGitCommitIndex.new({})
     )
 
-    assert_equal ["S-05:AC-1"], tracker.criterion_statuses(filter: "S-05").map { |row| row.reference.to_s }
-    assert_equal ["S-06:AC-1"], tracker.criterion_statuses(filter: "S-06:AC-1").map { |row| row.reference.to_s }
+    assert_equal [ "S-05:AC-1" ], tracker.criterion_statuses(filter: "S-05").map { |row| row.reference.to_s }
+    assert_equal [ "S-06:AC-1" ], tracker.criterion_statuses(filter: "S-06:AC-1").map { |row| row.reference.to_s }
   end
 end


### PR DESCRIPTION
## Overview

This PR adds a **spec sync system** to track which acceptance criteria from product specifications have been implemented, are in-progress, blocked, or still todo.

The system bridges your spec documents (S-01 through S-09) with your git history and manual status tracking, providing a single source of truth for acceptance criteria implementation status.

## What It Does

### 1. **Parses Specification Documents**
- Reads specs from `specs/app/[0-9][0-9]-*.md`
- Extracts acceptance criteria from markdown tables (section 8)
- Stores spec metadata: ID, title, status, and confidence levels

### 2. **Validates Criterion References**
- Format: `S-NN:AC-N` (e.g., `S-05:AC-1`)
- Validates structure and maps to actual criteria

### 3. **Tracks Manual Status**
- Persistent YAML store (`specs/implementation_status.yml`)
- Three manual statuses: `todo`, `in_progress`, `blocked`
- Tracks when and who last updated each criterion

### 4. **Auto-detects Implementation from Git**
- Scans commit messages for criterion references
- Links commits to criteria that mention them
- Marks criteria as "done" if any commit references them

### 5. **Aggregates Implementation Status**
- **Logic:**
  - If manually marked `in_progress` or `blocked` → use that
  - Else if any git commits mention it → `done`
  - Else → `todo`

## Rake Tasks

```bash
# View implementation status, optionally filtered by spec or criterion
bundle exec rake "spec_sync:status[S-05]"           # Show S-05 criteria
bundle exec rake "spec_sync:status[S-05:AC-1]"      # Show one criterion
bundle exec rake spec_sync:status                   # Show all criteria

# Manually mark a criterion's status
bundle exec rake "spec_sync:mark[S-05:AC-1,in_progress,Building wizard UI]"

# Validate configuration is correct
bundle exec rake spec_sync:validate
```

## Files Added

```
lib/spec_sync.rb                              # Module namespace
lib/spec_sync/
  ├── acceptance_criterion.rb                 # Data class for criteria
  ├── catalog.rb                              # Spec parser
  ├── commit_link.rb                          # Data class for git links
  ├── git_commit_index.rb                     # Git history indexer
  ├── reference.rb                            # Criterion reference parser
  ├── spec_document.rb                        # Data class for specs
  ├── status_store.rb                         # YAML persistence
  └── tracker.rb                              # Status aggregator
lib/tasks/spec_sync.rake                      # Rake task definitions
specs/implementation_status.yml               # Status store (initially empty)
test/lib/spec_sync/
  ├── catalog_test.rb                         # Spec parsing tests
  ├── status_store_test.rb                    # Persistence tests
  └── tracker_test.rb                         # Status aggregation tests
```

## Key Design Decisions

### Immutable Value Objects
Used Ruby `Data.define()` for all value types (AcceptanceCriterion, SpecDocument, CommitLink) to ensure immutability and predictable equality semantics.

### Sparse Status Store
Only stores manual overrides in YAML. Criteria not mentioned default to `todo`. This keeps the file small and easy to review.

### Git History as Signal
Commits mention criteria references (`S-NN:AC-N`) in messages, and the system automatically indexes these. No explicit linking needed.

### Stateless Tracker
The Tracker is computed on-demand from current Catalog, StatusStore, and GitCommitIndex state. No caching—always accurate.

## Tests

All tests pass:
- ✅ `test/lib/spec_sync/catalog_test.rb` — Spec parsing
- ✅ `test/lib/spec_sync/status_store_test.rb` — Manual status persistence  
- ✅ `test/lib/spec_sync/tracker_test.rb` — Status aggregation logic

```bash
bundle exec rails test test/lib/spec_sync    # 5 tests
bundle exec rails test                       # 15 tests (including existing ones)
```

## Example Usage

```ruby
# Get all criteria for a spec
tracker = SpecSync::Tracker.new
tracker.criterion_statuses(filter: "S-05")

# Each returns:
[
  {
    reference: "S-05:AC-1",
    spec_title: "Character Creation",
    spec_status: "Draft",
    spec_path: "specs/app/05-character-creation.md",
    type: "Behavioral",
    criterion: "The creation flow collects all fields...",
    spec_confidence: "[Assumed: verify]",
    implementation_status: "todo",           # auto-computed
    manual_status: nil,
    commit_links: []
  },
  ...
]
```

## Bugs Fixed During Implementation

1. **Status Normalization** — Markdown backticks in table cells were leaking into parsed values. Added normalization to strip them.

2. **Autoload Path Issue** — Value objects defined inline in class files weren't reliably autoloaded. Extracted to Zeitwerk-friendly standalone files.

3. **Git History Parser** — Tokenization was fragile and crashed on multi-paragraph commit messages. Switched to explicit record separators (`\x1e`) with validation.

## Next Steps (Future)

- [ ] Add web UI to view and manage criteria status
- [ ] Integrate with CI/CD to auto-mark criteria on test pass
- [ ] Link criteria to actual code (models, controllers)
- [ ] Generate coverage reports showing spec-to-code alignment
- [ ] Add GitHub issue linking for blocked/todo criteria